### PR TITLE
Init with multiple branches

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0
 commit = True
 tag = True
 

--- a/README.rst
+++ b/README.rst
@@ -44,12 +44,10 @@ To start autodeploy with multiple branches
             {
                 'name': 'deploy/test',
                 'script': '/var/www/myProject/test-deploy.sh',
-                'is_branch_name_to_cli': False
             },
             {
                 'regexp': r'feature/.*',
-                'script': '/var/www/myProject/feature-deploy.sh',
-                'is_branch_name_to_cli': True
+                'script': '/var/www/myProject/feature-deploy.sh'
             }
         ]
     })

--- a/README.rst
+++ b/README.rst
@@ -26,6 +26,34 @@ To start your first autodeploy daemon you need to create `deploy.py` script file
                   'git pull;'
     })
 
+To start autodeploy with multiple branches
+
+.. code:: python
+
+    import deployserver
+
+
+    deployserver.init({
+        'server_address': 'http://mydomain.com',
+        'port': 1234,
+        'branches': [
+            {
+                'name': 'master',
+                'script': '/var/www/myProject/master-deploy.sh'
+            },
+            {
+                'name': 'deploy/test',
+                'script': '/var/www/myProject/test-deploy.sh',
+                'is_branch_name_to_cli': False
+            },
+            {
+                'regexp': r'feature/.*',
+                'script': '/var/www/myProject/feature-deploy.sh',
+                'is_branch_name_to_cli': True
+            }
+        ]
+    })
+
 Then you need to run this script.
 
 .. code:: bash

--- a/deployserver/__init__.py
+++ b/deployserver/__init__.py
@@ -249,7 +249,7 @@ def init(settings):
             if can_deploy:
                 script = item.get('script', None)
 
-                print('Run deploy script [' + script + '] for branch [' + current_branch + ']...')
+                print('Run deploy script [{}] for branch [{}]...', script, current_branch)
 
                 os.system(script)
 

--- a/deployserver/__init__.py
+++ b/deployserver/__init__.py
@@ -183,7 +183,8 @@ def init(settings):
 
             print('Got a {} event in {} branch.'.format(event, branch))
 
-            if params['branch'].split('/')[-1] == branch:
+            # params branch name without "refs/heads/"
+            if params['branch'][11:] == branch:
                 can_deploy = True
 
         elif event == 'pullrequest:fulfilled':
@@ -192,7 +193,8 @@ def init(settings):
 
             print('Got a {} event into {} branch.'.format(event, branch))
 
-            if params['branch'].split('/')[-1] == branch:
+            # params branch name without "refs/heads/"
+            if params['branch'][11:] == branch:
                 can_deploy = True
 
         if can_deploy:

--- a/deployserver/__init__.py
+++ b/deployserver/__init__.py
@@ -249,7 +249,7 @@ def init(settings):
             if can_deploy:
                 script = item.get('script', None)
 
-                print('Run deploy script [{}] for branch [{}]...', script, current_branch)
+                print('Run deploy script [{}] for branch [{}]...'.format(script, current_branch))
 
                 os.system(script)
 

--- a/deployserver/__init__.py
+++ b/deployserver/__init__.py
@@ -65,7 +65,7 @@ def init(settings):
                         'script': '/var/www/myProject/deploy.sh'
                     },
                     {
-                        'regexp': 'testing/*',
+                        'regexp': r'testing/.*',
                         'script': '/var/www/myProject/deploy.sh'
                     }
                 ]

--- a/deployserver/__init__.py
+++ b/deployserver/__init__.py
@@ -56,6 +56,20 @@ def init(settings):
         example: 'current-sprint'
                  'ver2'
 
+    params['branches'] : list of dict
+        (optional) List of branches which push event should initiate deploy
+        default: []
+        example: [
+                    {
+                        'name': 'master',
+                        'script': '/var/www/myProject/deploy.sh'
+                    },
+                    {
+                        'regexp': 'testing/*',
+                        'script': '/var/www/myProject/deploy.sh'
+                    }
+                ]
+
     params['uri'] : string
         (optional) Callback uri.
         default: '/callback'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='deployserver',
-    version='0.4.0',
+    version='0.5.0',
     packages = find_packages(),
     description='Deploy your project automatically when git branch was updated.',
     long_description=open(join(dirname(__file__), 'README.rst')).read(),


### PR DESCRIPTION
Добавлено:
* возможность настраивать автоматический деплой на несколько веток
* регулярные выражения для определения названия веток
* обратный вызов `deployscript` с передачей в cli параметра c названием ветки (эту функциональность регулирует флаг `params['branches']['is_branch_name_to_cli'])`

* поправил проверку веток для bitbucket (не мог отследить название веток вида `deploy/test`)